### PR TITLE
Prevent Retries 5xx Errors for Non-Idempotent Requests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
@@ -86,7 +86,19 @@ public class ErrorHandlers {
         case 404:
           throw new NoSuchTableException("%s", error.message());
         case 409:
-          throw new CommitFailedException("Commit failed: %s", error.message());
+          if (error.wasRetried()) {
+            // If a retried request finally fails with 409,
+            // the IRC service may have persisted the commit
+            // despite initial 5xx errors, resulting in a self-conflict on retry
+            // due to the base changing.
+            // Mark this failure as commit state unknown rather than failed to prevent file cleanup.
+            throw new CommitStateUnknownException(
+                new RESTException(
+                    "Commit status unknown, due to retries: %s: %s",
+                    error.code(), error.message()));
+          } else {
+            throw new CommitFailedException("Commit failed: %s", error.message());
+          }
         case 500:
         case 502:
         case 504:

--- a/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
@@ -86,19 +86,7 @@ public class ErrorHandlers {
         case 404:
           throw new NoSuchTableException("%s", error.message());
         case 409:
-          if (error.wasRetried()) {
-            // If a retried request finally fails with 409,
-            // the IRC service may have persisted the commit
-            // despite initial 5xx errors, resulting in a self-conflict on retry
-            // due to the base changing.
-            // Mark this failure as commit state unknown rather than failed to prevent file cleanup.
-            throw new CommitStateUnknownException(
-                new RESTException(
-                    "Commit status unknown, due to retries: %s: %s",
-                    error.code(), error.message()));
-          } else {
-            throw new CommitFailedException("Commit failed: %s", error.message());
-          }
+          throw new CommitFailedException("Commit failed: %s", error.message());
         case 500:
         case 502:
         case 503:

--- a/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
@@ -101,6 +101,7 @@ public class ErrorHandlers {
           }
         case 500:
         case 502:
+        case 503:
         case 504:
           throw new CommitStateUnknownException(
               new ServiceFailureException("Service failed: %s: %s", error.code(), error.message()));

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -60,9 +60,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  *
  * <ul>
  *   <li>SC_TOO_MANY_REQUESTS (429)
- *   <li>SC_BAD_GATEWAY (502)
  *   <li>SC_SERVICE_UNAVAILABLE (503)
- *   <li>SC_GATEWAY_TIMEOUT (504)
  * </ul>
  *
  * Most code and behavior is taken from {@link
@@ -79,11 +77,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
         maximumRetries > 0, "Cannot set retries to %s, the value must be positive", maximumRetries);
     this.maxRetries = maximumRetries;
     this.retriableCodes =
-        ImmutableSet.of(
-            HttpStatus.SC_TOO_MANY_REQUESTS,
-            HttpStatus.SC_SERVICE_UNAVAILABLE,
-            HttpStatus.SC_BAD_GATEWAY,
-            HttpStatus.SC_GATEWAY_TIMEOUT);
+        ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS, HttpStatus.SC_SERVICE_UNAVAILABLE);
     this.nonRetriableExceptions =
         ImmutableSet.of(
             InterruptedIOException.class,
@@ -118,20 +112,12 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     }
 
     // Retry if the request is considered idempotent
-    boolean shouldRetry = Method.isIdempotent(request.getMethod());
-    if (shouldRetry && context != null) {
-      context.setAttribute("was-retried", Boolean.TRUE);
-    }
-    return shouldRetry;
+    return Method.isIdempotent(request.getMethod());
   }
 
   @Override
   public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
-    boolean shouldRetry = execCount <= maxRetries && retriableCodes.contains(response.getCode());
-    if (shouldRetry && context != null) {
-      context.setAttribute("was-retried", Boolean.TRUE);
-    }
-    return shouldRetry;
+    return execCount <= maxRetries && retriableCodes.contains(response.getCode());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -118,12 +118,20 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     }
 
     // Retry if the request is considered idempotent
-    return Method.isIdempotent(request.getMethod());
+    boolean shouldRetry = Method.isIdempotent(request.getMethod());
+    if (shouldRetry && context != null) {
+      context.setAttribute("was-retried", Boolean.TRUE);
+    }
+    return shouldRetry;
   }
 
   @Override
   public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
-    return execCount <= maxRetries && retriableCodes.contains(response.getCode());
+    boolean shouldRetry = execCount <= maxRetries && retriableCodes.contains(response.getCode());
+    if (shouldRetry && context != null) {
+      context.setAttribute("was-retried", Boolean.TRUE);
+    }
+    return shouldRetry;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -38,6 +38,7 @@ import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.http.protocol.HttpCoreContext;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -64,7 +65,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  * </ul>
  *
  * The following retriable HTTP status codes are defined for idempotent requests:
+<<<<<<< HEAD
  *
+=======
+>>>>>>> 4c08be5c6 (Core: Allow retries for Idempotent Requests with Certain Codes)
  * <ul>
  *   <li>SC_TOO_MANY_REQUESTS (429)
  *   <li>SC_SERVICE_UNAVAILABLE (503)
@@ -83,6 +87,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
   private final int maxRetries;
   private final Set<Class<? extends IOException>> nonRetriableExceptions;
   private final Set<Integer> retriableCodes;
+  private final Set<Integer> idempotentRetriableCodes;
 
   ExponentialHttpRequestRetryStrategy(int maximumRetries) {
     Preconditions.checkArgument(
@@ -92,13 +97,13 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
         ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS, HttpStatus.SC_SERVICE_UNAVAILABLE);
     this.idempotentRetriableCodes =
         ImmutableSet.of(
-            HttpStatus.SC_TOO_MANY_REQUESTS,
-            HttpStatus.SC_SERVICE_UNAVAILABLE,
-            HttpStatus.SC_INTERNAL_SERVER_ERROR,
-            HttpStatus.SC_SERVICE_UNAVAILABLE,
-            HttpStatus.SC_BAD_GATEWAY,
-            HttpStatus.SC_GATEWAY_TIMEOUT,
-            HttpStatus.SC_REQUEST_TIMEOUT);
+          HttpStatus.SC_TOO_MANY_REQUESTS,
+          HttpStatus.SC_SERVICE_UNAVAILABLE,
+          HttpStatus.SC_INTERNAL_SERVER_ERROR,
+          HttpStatus.SC_SERVICE_UNAVAILABLE,
+          HttpStatus.SC_BAD_GATEWAY,
+          HttpStatus.SC_GATEWAY_TIMEOUT,
+          HttpStatus.SC_REQUEST_TIMEOUT);
     this.nonRetriableExceptions =
         ImmutableSet.of(
             InterruptedIOException.class,
@@ -138,16 +143,17 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
 
   @Override
   public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
-    HttpRequest request =
-        context instanceof HttpCoreContext ? ((HttpCoreContext) context).getRequest() : null;
+    HttpRequest request = context instanceof HttpCoreContext ?
+      ((HttpCoreContext) context).getRequest() : null;
 
     boolean shouldRetry =
-        execCount <= maxRetries
-            && (retriableCodes.contains(response.getCode())
-                || shouldRetryIdempotent(request, response.getCode()));
+      execCount <= maxRetries &&
+        (retriableCodes.contains(response.getCode()) ||
+          shouldRetryIdempotent(request, response.getCode()));
 
     return shouldRetry;
   }
+
 
   @Override
   public TimeValue getRetryInterval(HttpResponse response, int execCount, HttpContext context) {
@@ -160,8 +166,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       try {
         retryAfter = TimeValue.ofSeconds(Long.parseLong(value));
       } catch (NumberFormatException ignore) {
-        Instant retryAfterDate = DateUtils.parseStandardDate(value);
-        if (retryAfterDate != null) {
+        Instant retryAfterDate = DateUtils.parseStandardDate(value); if (retryAfterDate != null) {
           retryAfter =
               TimeValue.ofMilliseconds(retryAfterDate.toEpochMilli() - System.currentTimeMillis());
         }
@@ -184,7 +189,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     }
 
     // Check if the request is idempotent
-    return Method.isIdempotent(request.getMethod())
-        && idempotentRetriableCodes.contains(responseCode);
+    return Method.isIdempotent(request.getMethod()) &&
+      idempotentRetriableCodes.contains(responseCode);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -94,7 +94,6 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     this.idempotentRetriableCodes =
         ImmutableSet.of(
           HttpStatus.SC_TOO_MANY_REQUESTS,
-          HttpStatus.SC_SERVICE_UNAVAILABLE,
           HttpStatus.SC_INTERNAL_SERVER_ERROR,
           HttpStatus.SC_SERVICE_UNAVAILABLE,
           HttpStatus.SC_BAD_GATEWAY,
@@ -162,7 +161,8 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       try {
         retryAfter = TimeValue.ofSeconds(Long.parseLong(value));
       } catch (NumberFormatException ignore) {
-        Instant retryAfterDate = DateUtils.parseStandardDate(value); if (retryAfterDate != null) {
+        Instant retryAfterDate = DateUtils.parseStandardDate(value);
+        if (retryAfterDate != null) {
           retryAfter =
               TimeValue.ofMilliseconds(retryAfterDate.toEpochMilli() - System.currentTimeMillis());
         }

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -94,7 +94,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
         maximumRetries > 0, "Cannot set retries to %s, the value must be positive", maximumRetries);
     this.maxRetries = maximumRetries;
     this.retriableCodes =
-        ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS, HttpStatus.SC_SERVICE_UNAVAILABLE);
+        ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS);
     this.idempotentRetriableCodes =
         ImmutableSet.of(
           HttpStatus.SC_TOO_MANY_REQUESTS,

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -63,6 +63,18 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  *   <li>SC_SERVICE_UNAVAILABLE (503)
  * </ul>
  *
+ * The following retriable HTTP status codes are defined for idempotent requests:
+ *
+ * <ul>
+ *   <li>SC_TOO_MANY_REQUESTS (429)
+ *   <li>SC_SERVICE_UNAVAILABLE (503)
+ *   <li>SC_INTERNAL_SERVER_ERROR (500)
+ *   <li>SC_BAD_GATEWAY (502)
+ *   <li>SC_GATEWAY_TIMEOUT (504)
+ *   <li>SC_REQUEST_TIMEOUT (408)
+ *   <li>SC_SERVICE_UNAVAILABLE (503)
+ * </ul>
+ *
  * Most code and behavior is taken from {@link
  * org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy}, with minor modifications to
  * {@link #getRetryInterval(HttpResponse, int, HttpContext)} to achieve exponential backoff.
@@ -78,6 +90,15 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     this.maxRetries = maximumRetries;
     this.retriableCodes =
         ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS, HttpStatus.SC_SERVICE_UNAVAILABLE);
+    this.idempotentRetriableCodes =
+        ImmutableSet.of(
+            HttpStatus.SC_TOO_MANY_REQUESTS,
+            HttpStatus.SC_SERVICE_UNAVAILABLE,
+            HttpStatus.SC_INTERNAL_SERVER_ERROR,
+            HttpStatus.SC_SERVICE_UNAVAILABLE,
+            HttpStatus.SC_BAD_GATEWAY,
+            HttpStatus.SC_GATEWAY_TIMEOUT,
+            HttpStatus.SC_REQUEST_TIMEOUT);
     this.nonRetriableExceptions =
         ImmutableSet.of(
             InterruptedIOException.class,
@@ -117,7 +138,15 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
 
   @Override
   public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
-    return execCount <= maxRetries && retriableCodes.contains(response.getCode());
+    HttpRequest request =
+        context instanceof HttpCoreContext ? ((HttpCoreContext) context).getRequest() : null;
+
+    boolean shouldRetry =
+        execCount <= maxRetries
+            && (retriableCodes.contains(response.getCode())
+                || shouldRetryIdempotent(request, response.getCode()));
+
+    return shouldRetry;
   }
 
   @Override
@@ -147,5 +176,15 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     int jitter = ThreadLocalRandom.current().nextInt(Math.max(1, (int) (delayMillis * 0.1)));
 
     return TimeValue.ofMilliseconds(delayMillis + jitter);
+  }
+
+  private boolean shouldRetryIdempotent(HttpRequest request, int responseCode) {
+    if (request == null) {
+      return false;
+    }
+
+    // Check if the request is idempotent
+    return Method.isIdempotent(request.getMethod())
+        && idempotentRetriableCodes.contains(responseCode);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -65,10 +65,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  * </ul>
  *
  * The following retriable HTTP status codes are defined for idempotent requests:
-<<<<<<< HEAD
- *
-=======
->>>>>>> 4c08be5c6 (Core: Allow retries for Idempotent Requests with Certain Codes)
  * <ul>
  *   <li>SC_TOO_MANY_REQUESTS (429)
  *   <li>SC_SERVICE_UNAVAILABLE (503)

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -46,6 +46,8 @@ import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.impl.EnglishReasonPhraseCatalog;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.common.DynConstructors;
@@ -184,7 +186,10 @@ public class HTTPClient extends BaseHTTPClient {
   // Process a failed response through the provided errorHandler, and throw a RESTException if the
   // provided error handler doesn't already throw.
   private static void throwFailure(
-      CloseableHttpResponse response, String responseBody, Consumer<ErrorResponse> errorHandler) {
+      CloseableHttpResponse response,
+      String responseBody,
+      Consumer<ErrorResponse> errorHandler,
+      Object wasRetried) {
     ErrorResponse errorResponse = null;
 
     if (responseBody != null) {
@@ -221,10 +226,19 @@ public class HTTPClient extends BaseHTTPClient {
       errorResponse = buildDefaultErrorResponse(response);
     }
 
-    errorHandler.accept(errorResponse);
+    ErrorResponse enrichedErrorResponse =
+        ErrorResponse.builder()
+            .wasRetried(wasRetried == Boolean.TRUE)
+            .responseCode(errorResponse.code())
+            .withMessage(errorResponse.message())
+            .withType(errorResponse.type())
+            .withStackTrace(errorResponse.stack())
+            .build();
+
+    errorHandler.accept(enrichedErrorResponse);
 
     // Throw an exception in case the provided error handler does not throw.
-    throw new RESTException("Unhandled error: %s", errorResponse);
+    throw new RESTException("Unhandled error: %s", enrichedErrorResponse);
   }
 
   @Override
@@ -287,7 +301,8 @@ public class HTTPClient extends BaseHTTPClient {
       request.setEntity(new StringEntity(encodedBody));
     }
 
-    try (CloseableHttpResponse response = httpClient.execute(request)) {
+    HttpContext context = new BasicHttpContext();
+    try (CloseableHttpResponse response = httpClient.execute(request, context)) {
       Map<String, String> respHeaders = Maps.newHashMap();
       for (Header header : response.getHeaders()) {
         respHeaders.put(header.getName(), header.getValue());
@@ -305,7 +320,7 @@ public class HTTPClient extends BaseHTTPClient {
 
       if (!isSuccessful(response)) {
         // The provided error handler is expected to throw, but a RESTException is thrown if not.
-        throwFailure(response, responseBody, errorHandler);
+        throwFailure(response, responseBody, errorHandler, context.getAttribute("was-retried"));
       }
 
       if (responseBody == null) {

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -36,6 +36,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
@@ -46,6 +47,7 @@ import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.impl.EnglishReasonPhraseCatalog;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.common.DynConstructors;
@@ -287,7 +289,8 @@ public class HTTPClient extends BaseHTTPClient {
       request.setEntity(new StringEntity(encodedBody));
     }
 
-    try (CloseableHttpResponse response = httpClient.execute(request)) {
+    HttpContext context = HttpClientContext.create();
+    try (CloseableHttpResponse response = httpClient.execute(request, context)) {
       Map<String, String> respHeaders = Maps.newHashMap();
       for (Header header : response.getHeaders()) {
         respHeaders.put(header.getName(), header.getValue());

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -46,8 +46,6 @@ import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.impl.EnglishReasonPhraseCatalog;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.core5.http.protocol.BasicHttpContext;
-import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.common.DynConstructors;
@@ -186,10 +184,7 @@ public class HTTPClient extends BaseHTTPClient {
   // Process a failed response through the provided errorHandler, and throw a RESTException if the
   // provided error handler doesn't already throw.
   private static void throwFailure(
-      CloseableHttpResponse response,
-      String responseBody,
-      Consumer<ErrorResponse> errorHandler,
-      Object wasRetried) {
+      CloseableHttpResponse response, String responseBody, Consumer<ErrorResponse> errorHandler) {
     ErrorResponse errorResponse = null;
 
     if (responseBody != null) {
@@ -226,19 +221,10 @@ public class HTTPClient extends BaseHTTPClient {
       errorResponse = buildDefaultErrorResponse(response);
     }
 
-    ErrorResponse enrichedErrorResponse =
-        ErrorResponse.builder()
-            .wasRetried(wasRetried == Boolean.TRUE)
-            .responseCode(errorResponse.code())
-            .withMessage(errorResponse.message())
-            .withType(errorResponse.type())
-            .withStackTrace(errorResponse.stack())
-            .build();
-
-    errorHandler.accept(enrichedErrorResponse);
+    errorHandler.accept(errorResponse);
 
     // Throw an exception in case the provided error handler does not throw.
-    throw new RESTException("Unhandled error: %s", enrichedErrorResponse);
+    throw new RESTException("Unhandled error: %s", errorResponse);
   }
 
   @Override
@@ -301,8 +287,7 @@ public class HTTPClient extends BaseHTTPClient {
       request.setEntity(new StringEntity(encodedBody));
     }
 
-    HttpContext context = new BasicHttpContext();
-    try (CloseableHttpResponse response = httpClient.execute(request, context)) {
+    try (CloseableHttpResponse response = httpClient.execute(request)) {
       Map<String, String> respHeaders = Maps.newHashMap();
       for (Header header : response.getHeaders()) {
         respHeaders.put(header.getName(), header.getValue());
@@ -320,7 +305,7 @@ public class HTTPClient extends BaseHTTPClient {
 
       if (!isSuccessful(response)) {
         // The provided error handler is expected to throw, but a RESTException is thrown if not.
-        throwFailure(response, responseBody, errorHandler, context.getAttribute("was-retried"));
+        throwFailure(response, responseBody, errorHandler);
       }
 
       if (responseBody == null) {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
@@ -32,15 +32,12 @@ public class ErrorResponse implements RESTResponse {
   private final String type;
   private final int code;
   private final List<String> stack;
-  private final boolean wasRetried;
 
-  private ErrorResponse(
-      String message, String type, int code, List<String> stack, boolean wasRetried) {
+  private ErrorResponse(String message, String type, int code, List<String> stack) {
     this.message = message;
     this.type = type;
     this.code = code;
     this.stack = stack;
-    this.wasRetried = wasRetried;
     validate();
   }
 
@@ -63,10 +60,6 @@ public class ErrorResponse implements RESTResponse {
 
   public List<String> stack() {
     return stack;
-  }
-
-  public boolean wasRetried() {
-    return wasRetried;
   }
 
   @Override
@@ -99,7 +92,6 @@ public class ErrorResponse implements RESTResponse {
     private String type;
     private Integer code;
     private List<String> stack;
-    private boolean wasRetried;
 
     private Builder() {}
 
@@ -134,14 +126,9 @@ public class ErrorResponse implements RESTResponse {
       return this;
     }
 
-    public Builder wasRetried(boolean hasBeenRetried) {
-      this.wasRetried = hasBeenRetried;
-      return this;
-    }
-
     public ErrorResponse build() {
       Preconditions.checkArgument(code != null, "Invalid response, missing field: code");
-      return new ErrorResponse(message, type, code, stack, wasRetried);
+      return new ErrorResponse(message, type, code, stack);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
@@ -32,12 +32,15 @@ public class ErrorResponse implements RESTResponse {
   private final String type;
   private final int code;
   private final List<String> stack;
+  private final boolean wasRetried;
 
-  private ErrorResponse(String message, String type, int code, List<String> stack) {
+  private ErrorResponse(
+      String message, String type, int code, List<String> stack, boolean wasRetried) {
     this.message = message;
     this.type = type;
     this.code = code;
     this.stack = stack;
+    this.wasRetried = wasRetried;
     validate();
   }
 
@@ -60,6 +63,10 @@ public class ErrorResponse implements RESTResponse {
 
   public List<String> stack() {
     return stack;
+  }
+
+  public boolean wasRetried() {
+    return wasRetried;
   }
 
   @Override
@@ -92,6 +99,7 @@ public class ErrorResponse implements RESTResponse {
     private String type;
     private Integer code;
     private List<String> stack;
+    private boolean wasRetried;
 
     private Builder() {}
 
@@ -126,9 +134,14 @@ public class ErrorResponse implements RESTResponse {
       return this;
     }
 
+    public Builder wasRetried(boolean hasBeenRetried) {
+      this.wasRetried = hasBeenRetried;
+      return this;
+    }
+
     public ErrorResponse build() {
       Preconditions.checkArgument(code != null, "Invalid response, missing field: code");
-      return new ErrorResponse(message, type, code, stack);
+      return new ErrorResponse(message, type, code, stack, wasRetried);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -37,6 +37,8 @@ import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -80,14 +82,20 @@ public class TestExponentialHttpRequestRetryStrategy {
 
   @Test
   public void basicRetry() {
+    HttpContext context503 = new BasicHttpContext();
     BasicHttpResponse response503 = new BasicHttpResponse(503, "Oopsie");
-    assertThat(retryStrategy.retryRequest(response503, 3, null)).isTrue();
+    assertThat(retryStrategy.retryRequest(response503, 3, context503)).isTrue();
+    assertThat(context503.getAttribute("was-retried") == Boolean.TRUE).isTrue();
 
+    HttpContext context429 = new BasicHttpContext();
     BasicHttpResponse response429 = new BasicHttpResponse(429, "Oopsie");
-    assertThat(retryStrategy.retryRequest(response429, 3, null)).isTrue();
+    assertThat(retryStrategy.retryRequest(response429, 3, context429)).isTrue();
+    assertThat(context429.getAttribute("was-retried") == Boolean.TRUE).isTrue();
 
+    HttpContext context404 = new BasicHttpContext();
     BasicHttpResponse response404 = new BasicHttpResponse(404, "Oopsie");
-    assertThat(retryStrategy.retryRequest(response404, 3, null)).isFalse();
+    assertThat(retryStrategy.retryRequest(response404, 3, context404)).isFalse();
+    assertThat(context429.getAttribute("was-retried") == Boolean.TRUE).isTrue();
   }
 
   @Test
@@ -155,8 +163,9 @@ public class TestExponentialHttpRequestRetryStrategy {
   @Test
   public void retryOnNonAbortedRequests() {
     HttpGet request = new HttpGet("/");
+    HttpContext context = new BasicHttpContext();
 
-    assertThat(retryStrategy.retryRequest(request, new IOException(), 1, null)).isTrue();
+    assertThat(retryStrategy.retryRequest(request, new IOException(), 1, context)).isTrue();
   }
 
   @Test
@@ -199,13 +208,15 @@ public class TestExponentialHttpRequestRetryStrategy {
 
   @Test
   public void testRetryBadGateway() {
+    HttpContext context = new BasicHttpContext();
     BasicHttpResponse response502 = new BasicHttpResponse(502, "Bad gateway failure");
-    assertThat(retryStrategy.retryRequest(response502, 3, null)).isTrue();
+    assertThat(retryStrategy.retryRequest(response502, 3, context)).isTrue();
   }
 
   @Test
   public void testRetryGatewayTimeout() {
+    HttpContext context = new BasicHttpContext();
     BasicHttpResponse response504 = new BasicHttpResponse(504, "Gateway timeout");
-    assertThat(retryStrategy.retryRequest(response504, 3, null)).isTrue();
+    assertThat(retryStrategy.retryRequest(response504, 3, context)).isTrue();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -32,11 +32,15 @@ import java.time.temporal.ChronoUnit;
 import javax.net.ssl.SSLException;
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
 import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -209,5 +213,14 @@ public class TestExponentialHttpRequestRetryStrategy {
   public void testRetryDoesNotHappenOnUnacceptableStatusCodes(int statusCode) {
     BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
     assertThat(retryStrategy.retryRequest(response, 3, null)).isFalse();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {429, 503, 500, 502, 504, 408})
+  public void testRetryHappensWithIdempotentMethods(int statusCode) {
+    BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
+    HttpClientContext context = HttpClientContext.create();
+    context.setRequest(new BasicHttpRequest("GET", "/"));
+    assertThat(retryStrategy.retryRequest(response, 3, context)).isTrue();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -84,9 +84,6 @@ public class TestExponentialHttpRequestRetryStrategy {
 
   @Test
   public void basicRetry() {
-    BasicHttpResponse response503 = new BasicHttpResponse(503, "Oopsie");
-    assertThat(retryStrategy.retryRequest(response503, 3, null)).isTrue();
-
     BasicHttpResponse response429 = new BasicHttpResponse(429, "Oopsie");
     assertThat(retryStrategy.retryRequest(response429, 3, null)).isTrue();
 
@@ -202,21 +199,21 @@ public class TestExponentialHttpRequestRetryStrategy {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {429, 503})
+  @ValueSource(ints = {429})
   public void testRetryHappensOnAcceptableStatusCodes(int statusCode) {
     BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
     assertThat(retryStrategy.retryRequest(response, 3, null)).isTrue();
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {500, 502, 504})
+  @ValueSource(ints = {500, 502, 503, 504})
   public void testRetryDoesNotHappenOnUnacceptableStatusCodes(int statusCode) {
     BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
     assertThat(retryStrategy.retryRequest(response, 3, null)).isFalse();
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {429, 503, 500, 502, 504, 408})
+  @ValueSource(ints = {429, 503, 500, 502, 503, 504, 408})
   public void testRetryHappensWithIdempotentMethods(int statusCode) {
     BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
     HttpClientContext context = HttpClientContext.create();

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -61,6 +61,7 @@ import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableCommit;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ServiceFailureException;
@@ -91,6 +92,7 @@ import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -2592,6 +2594,24 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // what older REST servers would send back too
     verifyTableExistsFallbackToGETRequest(
         ConfigResponse.builder().withEndpoints(ImmutableList.of(Endpoint.V1_LOAD_TABLE)).build());
+  }
+
+  @Test
+  public void testErrorHandlingForConflicts() {
+    Consumer<ErrorResponse> errorResponseConsumer = ErrorHandlers.tableCommitHandler();
+    // server returning 409 with client without retrying
+    ErrorResponse errorResponse409WithoutRetries =
+        ErrorResponse.builder().responseCode(409).wasRetried(false).build();
+    Assertions.assertThrows(
+        CommitFailedException.class,
+        () -> errorResponseConsumer.accept(errorResponse409WithoutRetries));
+
+    // server returning 409, with retries.
+    ErrorResponse errorResponse409WithRetries =
+        ErrorResponse.builder().responseCode(409).wasRetried(true).build();
+    Assertions.assertThrows(
+        CommitStateUnknownException.class,
+        () -> errorResponseConsumer.accept(errorResponse409WithRetries));
   }
 
   private void verifyTableExistsFallbackToGETRequest(ConfigResponse configResponse) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -61,7 +61,6 @@ import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableCommit;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ServiceFailureException;
@@ -2594,24 +2593,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // what older REST servers would send back too
     verifyTableExistsFallbackToGETRequest(
         ConfigResponse.builder().withEndpoints(ImmutableList.of(Endpoint.V1_LOAD_TABLE)).build());
-  }
-
-  @Test
-  public void testErrorHandlingForConflicts() {
-    Consumer<ErrorResponse> errorResponseConsumer = ErrorHandlers.tableCommitHandler();
-    // server returning 409 with client without retrying
-    ErrorResponse errorResponse409WithoutRetries =
-        ErrorResponse.builder().responseCode(409).wasRetried(false).build();
-    Assertions.assertThrows(
-        CommitFailedException.class,
-        () -> errorResponseConsumer.accept(errorResponse409WithoutRetries));
-
-    // server returning 409, with retries.
-    ErrorResponse errorResponse409WithRetries =
-        ErrorResponse.builder().responseCode(409).wasRetried(true).build();
-    Assertions.assertThrows(
-        CommitStateUnknownException.class,
-        () -> errorResponseConsumer.accept(errorResponse409WithRetries));
   }
 
   private void verifyTableExistsFallbackToGETRequest(ConfigResponse configResponse) {


### PR DESCRIPTION
This PR prevents non-idempotent Request Methods (i.e. POSTs) from automatically retrying on 5xx errors. 

This prevents retries from corrupting table metadata in the event that a commit is applied and persisted in the catalog BE, but returns a 5xx error. If these requests are retried, subsequently Fail (i.e. with a 409), and attempt to cleanup the files they've written, table metadata will be corrupted.

This PR primarily contains cherry-picks from OSS PRs:
- [13352](https://github.com/apache/iceberg/pull/13352) - prevents retries on 502 and 504 errors
- [13449](https://github.com/apache/iceberg/pull/13449/files) - allow retries for 5xx's returned by idempotent requests (i.e. GET) 

And the following Affirm-authored updates:
- remove HttpStatus.SC_SERVICE_UNAVAILABLE from [retriableErrorCodes](https://github.com/Affirm/iceberg/blob/70ec963e4fa53314b09dd26310b08866178404b4/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java#L96), preventing 503 retries
- make 503 exceptions return a CommitStateUnkownException in ErrorHandlers.java

No regressions are introduced by these changes, all iceberg-core unit tests that were passing in apache-iceberg-1.8.1 are passing in this patch. 

![72](https://github.com/user-attachments/assets/fc09d2c8-46b9-4599-bf28-14319c5e8536)


The single failed test, TestHadoopCommits#testConcurrentFastAppends, is also failing on the iceberg 1.8.1 release tag. 
![72](https://github.com/user-attachments/assets/3c18042d-a10e-4d99-a5dc-0ff469314694)



